### PR TITLE
feat(autopilot): improve signaling visilibilty, roll up node failures into plan status

### DIFF
--- a/docs/autopilot.md
+++ b/docs/autopilot.md
@@ -333,6 +333,7 @@ update operation. There are a number of statuses available:
 | `Schedulable` | Indicates that the `Plan` can be re-evaluated to determine which next node to update. | No |
 | `SchedulableWait` | Scheduling operations are in progress, and no further update scheduling should occur. | No |
 | `Completed` | The `Plan` has run successfully to completion. | Yes |
+| `PlanApplyFailed` | One or more nodes encountered an unrecoverable error (e.g. download checksum mismatch). The `description` field on the command entry contains a summary of which nodes failed and why. | Yes |
 | `Restricted` | The `Plan` included node types (controller or worker) that violates the `--exclude-from-plans` restrictions. | Yes |
 
 ### Node Status
@@ -341,10 +342,51 @@ Similar to the **Plan Status**, the individual nodes can have their own statuses
 
 | Status | Description |
 | ------ | ----------- |
-| `SignalPending` | The node is available and awaiting an update signal |
+| `SignalPending` | The node is available and awaiting an update signal. |
 | `SignalSent` | Update signaling has been successfully applied to this node. |
+| `SignalCompleted` | The node has successfully applied the update. |
+| `SignalApplyFailed` | The node encountered an unrecoverable error. The `description` field contains the failure reason. |
 | `SignalMissingPlatform` | This node is a platform that an update has not been provided for. |
-| `SignalMissingNode` | This node does have an associated `Node` (worker) or `ControlNode` (controller) object. |
+| `SignalMissingNode` | This node does not have an associated `Node` (worker) or `ControlNode` (controller) object. |
+
+### Failure Diagnostics
+
+When a node reaches `SignalApplyFailed`, **autopilot** surfaces the failure details in two places:
+
+**Plan status** — the per-node `description` field and a rolled-up command-level `description`:
+
+```yaml
+status:
+  state: PlanApplyFailed
+  commands:
+    - state: PlanApplyFailed
+      description: "controller0: FailedDownload: sha256 mismatch (want 0000…0000, got a3f2…c1b9)"
+      k0supdate:
+        controllers:
+          - name: controller0
+            state: SignalApplyFailed
+            description: "FailedDownload: sha256 mismatch (want 0000…0000, got a3f2…c1b9)"
+            lastUpdatedTimestamp: "2026-03-12T12:34:56Z"
+```
+
+**Node annotation** — the `k0sproject.io/autopilot-last-error` annotation is written to both
+`ControlNode` (controller) and `Node` (worker) objects. It persists after the `Plan` is deleted
+and is cleared automatically when a new signal is dispatched to the node:
+
+```yaml
+metadata:
+  annotations:
+    k0sproject.io/autopilot-last-error: '{"planID":"id1234","reason":"FailedDownload","message":"sha256 mismatch (want 0000…0000, got a3f2…c1b9)","timestamp":"2026-03-12T12:34:56Z"}'
+```
+
+Fields in the annotation:
+
+| Field | Description |
+| ----- | ----------- |
+| `planID` | The `spec.id` of the `Plan` that triggered the failure. |
+| `reason` | The signal status code (e.g. `FailedDownload`). |
+| `message` | The raw error message (truncated at 1024 bytes). |
+| `timestamp` | RFC 3339 timestamp of when the failure occurred. |
 
 ## UpdateConfig
 

--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -15,6 +15,7 @@ smoketests := \
 	check-ap-quorumsafety \
 	check-ap-removedapis \
 	check-ap-selector \
+	check-ap-signal-error \
 	check-ap-single \
 	check-ap-updater \
 	check-ap-updater-periodic \

--- a/inttest/ap-signal-error/signal_error_test.go
+++ b/inttest/ap-signal-error/signal_error_test.go
@@ -1,0 +1,240 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package signalerror
+
+import (
+	"testing"
+
+	"github.com/k0sproject/k0s/inttest/common"
+	aptest "github.com/k0sproject/k0s/inttest/common/autopilot"
+	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
+	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
+	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
+	k0sclientset "github.com/k0sproject/k0s/pkg/client/clientset"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type apSignalErrorSuite struct {
+	common.BootlooseSuite
+}
+
+// SetupSuite starts k0s once for the whole suite so that each test method
+// can reuse the same running cluster without re-starting k0s.
+func (s *apSignalErrorSuite) SetupSuite() {
+	s.BootlooseSuite.SetupSuite()
+
+	ctx, nodeName, require := s.Context(), s.ControllerNode(0), s.Require()
+
+	ssh, err := s.SSH(ctx, nodeName)
+	require.NoError(err)
+	defer ssh.Disconnect()
+	require.NoError(ssh.Exec(ctx, "cp /dist/k0s /tmp/k0s", common.SSHStreams{}))
+
+	require.NoError(s.InitController(0, "--single", "--disable-components=metrics-server"))
+
+	client, err := s.KubeClient(nodeName)
+	require.NoError(err)
+	require.NoError(s.WaitForNodeReady(nodeName, client))
+
+	xClient, err := s.ExtensionsClient(nodeName)
+	require.NoError(err)
+	require.NoError(aptest.WaitForCRDByName(ctx, xClient, "plans"))
+	require.NoError(aptest.WaitForCRDByName(ctx, xClient, "controlnodes"))
+
+	// Wait for the ControlNode to be fully initialized with platform labels before
+	// any test submits a plan, avoiding SignalMissingPlatform from the newplan handler.
+	restConfig, err := s.GetKubeConfig(nodeName)
+	require.NoError(err)
+	k0sClient, err := k0sclientset.NewForConfig(restConfig)
+	require.NoError(err)
+	_, err = aptest.WaitForControlNodeReady(ctx, k0sClient, "controller0")
+	require.NoError(err, "While waiting for ControlNode to have platform labels")
+}
+
+// TearDownTest deletes the plan after each test to ensure a clean state for
+// the next test in the suite.
+func (s *apSignalErrorSuite) TearDownTest() {
+	ctx := s.Context()
+	restConfig, err := s.GetKubeConfig(s.ControllerNode(0))
+	if err != nil {
+		return
+	}
+	client, err := k0sclientset.NewForConfig(restConfig)
+	if err != nil {
+		return
+	}
+	_ = client.AutopilotV1beta2().Plans().Delete(ctx, apconst.AutopilotName, metav1.DeleteOptions{})
+}
+
+// TestControllerDownloadFailure submits a plan with a valid URL but wrong sha256,
+// verifies PlanApplyFailed is reached, and that the failure description is populated
+// in both the plan status and the ControlNode's autopilot-last-error annotation.
+func (s *apSignalErrorSuite) TestControllerDownloadFailure() {
+	ctx := s.Context()
+
+	restConfig, err := s.GetKubeConfig(s.ControllerNode(0))
+	s.Require().NoError(err)
+
+	planTemplate := `
+apiVersion: autopilot.k0sproject.io/v1beta2
+kind: Plan
+metadata:
+  name: autopilot
+spec:
+  id: id123
+  timestamp: now
+  commands:
+    - k0supdate:
+        version: v0.0.0
+        forceupdate: true
+        platforms:
+          linux-amd64:
+            url: http://localhost/dist/k0s
+            sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+          linux-arm64:
+            url: http://localhost/dist/k0s
+            sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+        targets:
+          controllers:
+            discovery:
+              static:
+                nodes:
+                  - controller0
+`
+
+	_, err = common.Create(ctx, restConfig, []byte(planTemplate))
+	s.Require().NoError(err)
+	s.T().Logf("Plan created")
+
+	client, err := k0sclientset.NewForConfig(restConfig)
+	s.Require().NoError(err)
+
+	plan, err := aptest.WaitForPlanState(ctx, client, apconst.AutopilotName, appc.PlanApplyFailed)
+	s.Require().NoError(err, "While waiting for plan to fail")
+
+	if s.Len(plan.Status.Commands, 1) {
+		cmd := plan.Status.Commands[0]
+		s.Equal(appc.PlanApplyFailed, cmd.State)
+		s.NotNil(cmd.K0sUpdate)
+		s.Contains(cmd.Description, "controller0", "command description should contain node name")
+		s.Contains(cmd.Description, "FailedDownload", "command description should contain failure reason")
+
+		if s.Len(cmd.K0sUpdate.Controllers, 1) {
+			ctrl := cmd.K0sUpdate.Controllers[0]
+			s.Equal(appc.SignalApplyFailed, ctrl.State)
+			s.Contains(ctrl.Description, "FailedDownload", "node description should contain failure reason")
+		}
+	}
+
+	signalErr, err := aptest.WaitForControlNodeSignalError(ctx, client, "controller0")
+	s.Require().NoError(err, "While waiting for ControlNode signal error to be set")
+	s.Equal("id123", signalErr.PlanID)
+	s.Equal("FailedDownload", signalErr.Reason)
+	s.NotEmpty(signalErr.Message)
+}
+
+// TestErrorClearedOnRetry verifies that a stale signal error is cleared when a
+// new plan is submitted after a failure.
+func (s *apSignalErrorSuite) TestErrorClearedOnRetry() {
+	ctx := s.Context()
+
+	restConfig, err := s.GetKubeConfig(s.ControllerNode(0))
+	s.Require().NoError(err)
+
+	client, err := k0sclientset.NewForConfig(restConfig)
+	s.Require().NoError(err)
+
+	// Phase 1: submit a plan with a bad sha256 to trigger a FailedDownload.
+	badPlan := `
+apiVersion: autopilot.k0sproject.io/v1beta2
+kind: Plan
+metadata:
+  name: autopilot
+spec:
+  id: id-bad
+  timestamp: now
+  commands:
+    - k0supdate:
+        version: v0.0.0
+        forceupdate: true
+        platforms:
+          linux-amd64:
+            url: http://localhost/dist/k0s
+            sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+          linux-arm64:
+            url: http://localhost/dist/k0s
+            sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+        targets:
+          controllers:
+            discovery:
+              static:
+                nodes:
+                  - controller0
+`
+	_, err = common.Create(ctx, restConfig, []byte(badPlan))
+	s.Require().NoError(err)
+
+	_, err = aptest.WaitForPlanState(ctx, client, apconst.AutopilotName, appc.PlanApplyFailed)
+	s.Require().NoError(err, "While waiting for plan to fail")
+
+	_, err = aptest.WaitForControlNodeSignalError(ctx, client, "controller0")
+	s.Require().NoError(err, "While waiting for ControlNode signal error to be set")
+
+	// Phase 2: delete the failed plan.
+	err = client.AutopilotV1beta2().Plans().Delete(ctx, apconst.AutopilotName, metav1.DeleteOptions{})
+	s.Require().NoError(err)
+
+	// Phase 3: submit a new plan with the correct URL and no sha256.
+	goodPlan := `
+apiVersion: autopilot.k0sproject.io/v1beta2
+kind: Plan
+metadata:
+  name: autopilot
+spec:
+  id: id-good
+  timestamp: now
+  commands:
+    - k0supdate:
+        version: v0.0.0
+        forceupdate: true
+        platforms:
+          linux-amd64:
+            url: http://localhost/dist/k0s
+          linux-arm64:
+            url: http://localhost/dist/k0s
+        targets:
+          controllers:
+            discovery:
+              static:
+                nodes:
+                  - controller0
+`
+	_, err = common.Create(ctx, restConfig, []byte(goodPlan))
+	s.Require().NoError(err)
+
+	_, err = aptest.WaitForPlanState(ctx, client, apconst.AutopilotName, appc.PlanCompleted)
+	s.Require().NoError(err, "While waiting for retry plan to complete")
+
+	// Phase 4: verify the signal error annotation is cleared on the ControlNode.
+	cn, err := client.AutopilotV1beta2().ControlNodes().Get(ctx, "controller0", metav1.GetOptions{})
+	s.Require().NoError(err)
+	_, hasError := cn.GetAnnotations()[apdel.SignalErrorAnnotation]
+	s.False(hasError, "autopilot-last-error annotation should be cleared after a successful signal")
+}
+
+// TestAPSignalErrorSuite runs the signal error test suite using a single
+// controller in --single mode.
+func TestAPSignalErrorSuite(t *testing.T) {
+	suite.Run(t, &apSignalErrorSuite{
+		common.BootlooseSuite{
+			K0sFullPath:     "/tmp/k0s",
+			ControllerCount: 1,
+			WorkerCount:     0,
+			LaunchMode:      common.LaunchModeOpenRC,
+		},
+	})
+}

--- a/inttest/common/autopilot/waitfor.go
+++ b/inttest/common/autopilot/waitfor.go
@@ -5,15 +5,18 @@ package autopilot
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot/v1beta2"
+	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
 	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
 	apclient "github.com/k0sproject/k0s/pkg/client/clientset"
 	"github.com/k0sproject/k0s/pkg/kubernetes/watch"
 
 	"github.com/k0sproject/k0s/inttest/common"
 
+	corev1 "k8s.io/api/core/v1"
 	extensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	extensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 
@@ -41,6 +44,48 @@ func WaitForPlanState(ctx context.Context, client apclient.Interface, name strin
 			}
 		})
 	return
+}
+
+// WaitForControlNodeReady watches the named ControlNode until it exists and has
+// its platform labels (kubernetes.io/os and kubernetes.io/arch) set, indicating
+// the autopilot controller has fully registered it.
+func WaitForControlNodeReady(ctx context.Context, client apclient.Interface, name string) (*apv1beta2.ControlNode, error) {
+	var cn *apv1beta2.ControlNode
+	err := watch.ControlNodes(client.AutopilotV1beta2().ControlNodes()).
+		WithObjectName(name).
+		WithErrorCallback(common.RetryWatchErrors(logrus.Infof)).
+		Until(ctx, func(candidate *apv1beta2.ControlNode) (bool, error) {
+			labels := candidate.GetLabels()
+			if labels[corev1.LabelOSStable] != "" && labels[corev1.LabelArchStable] != "" {
+				cn = candidate
+				return true, nil
+			}
+			return false, nil
+		})
+	return cn, err
+}
+
+// WaitForControlNodeSignalError watches the named ControlNode until the
+// k0sproject.io/autopilot-last-error annotation is present and returns the
+// parsed error, or the context times out.
+func WaitForControlNodeSignalError(ctx context.Context, client apclient.Interface, name string) (*apdel.SignalError, error) {
+	var signalError *apdel.SignalError
+	err := watch.ControlNodes(client.AutopilotV1beta2().ControlNodes()).
+		WithObjectName(name).
+		WithErrorCallback(common.RetryWatchErrors(logrus.Infof)).
+		Until(ctx, func(cn *apv1beta2.ControlNode) (bool, error) {
+			raw, ok := cn.GetAnnotations()[apdel.SignalErrorAnnotation]
+			if !ok {
+				return false, nil
+			}
+			var e apdel.SignalError
+			if err := json.Unmarshal([]byte(raw), &e); err != nil {
+				return false, nil
+			}
+			signalError = &e
+			return true, nil
+		})
+	return signalError, err
 }
 
 // WaitForCRDByName waits until the CRD with the given name is established.

--- a/pkg/apis/autopilot/v1beta2/types.go
+++ b/pkg/apis/autopilot/v1beta2/types.go
@@ -277,4 +277,9 @@ type PlanCommandTargetStatus struct {
 
 	// LastUpdatedTimestamp is a timestamp of the last time the status has changed.
 	LastUpdatedTimestamp metav1.Time `json:"lastUpdatedTimestamp"`
+
+	// Description is an optional human-readable explanation of the current state,
+	// populated when the node is in a failed state.
+	// +optional
+	Description string `json:"description,omitempty"`
 }

--- a/pkg/autopilot/controller/delegate/delegate.go
+++ b/pkg/autopilot/controller/delegate/delegate.go
@@ -34,6 +34,11 @@ type ControllerDelegate interface {
 
 	// K0sUpdate features
 	K0sUpdateReady(ctx context.Context, status apv1beta2.PlanCommandK0sUpdateStatus, obj crcli.Object) K0sUpdateReadyStatus
+
+	// Signal error features
+	ReadSignalError(obj crcli.Object) string
+	WriteSignalError(ctx context.Context, client crcli.Client, obj crcli.Object, planID, reason, message string) error
+	ClearSignalError(ctx context.Context, client crcli.Client, obj crcli.Object)
 }
 
 type createObjectFunc func() crcli.Object
@@ -42,6 +47,9 @@ type objectListToPlanCommandTargetStatusFunc func(list crcli.ObjectList, status 
 type createNamespacedNameFunc func(name string) types.NamespacedName
 type deepCopyFunc func(obj crcli.Object) crcli.Object
 type k0sUpdateReadyFunc func(context.Context, apv1beta2.PlanCommandK0sUpdateStatus, crcli.Object) K0sUpdateReadyStatus
+type readSignalErrorFunc func(obj crcli.Object) string
+type writeSignalErrorFunc func(ctx context.Context, client crcli.Client, obj crcli.Object, planID, reason, message string) error
+type clearSignalErrorFunc func(ctx context.Context, client crcli.Client, obj crcli.Object)
 
 type controllerDelegate struct {
 	name                                string
@@ -51,6 +59,9 @@ type controllerDelegate struct {
 	objectListToPlanCommandTargetStatus objectListToPlanCommandTargetStatusFunc
 	createNamespacedName                createNamespacedNameFunc
 	deepCopy                            deepCopyFunc
+	readSignalError                     readSignalErrorFunc
+	writeSignalError                    writeSignalErrorFunc
+	clearSignalError                    clearSignalErrorFunc
 }
 
 // Name returns the name of the delegate
@@ -86,4 +97,19 @@ func (d controllerDelegate) CreateNamespacedName(name string) types.NamespacedNa
 // DeepCopy creates a deep-copy of the object provided
 func (d controllerDelegate) DeepCopy(obj crcli.Object) crcli.Object {
 	return d.deepCopy(obj)
+}
+
+// ReadSignalError reads the signal error from the delegate object.
+func (d controllerDelegate) ReadSignalError(obj crcli.Object) string {
+	return d.readSignalError(obj)
+}
+
+// WriteSignalError writes the signal error to the delegate object.
+func (d controllerDelegate) WriteSignalError(ctx context.Context, client crcli.Client, obj crcli.Object, planID, reason, message string) error {
+	return d.writeSignalError(ctx, client, obj, planID, reason, message)
+}
+
+// ClearSignalError clears the signal error from the delegate object.
+func (d controllerDelegate) ClearSignalError(ctx context.Context, client crcli.Client, obj crcli.Object) {
+	d.clearSignalError(ctx, client, obj)
 }

--- a/pkg/autopilot/controller/delegate/signalerror.go
+++ b/pkg/autopilot/controller/delegate/signalerror.go
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package delegate
+
+import (
+	"encoding/json"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	crcli "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// SignalErrorAnnotation is the annotation key used on both ControlNode and Node
+// objects to persist the most recent signal processing failure.
+const SignalErrorAnnotation = "k0sproject.io/autopilot-last-error"
+
+// maxMessageLen is the maximum byte length for the message field before truncation.
+const maxMessageLen = 1024
+
+// SignalError holds details about a signal processing failure, stored as a JSON
+// annotation on both ControlNode and Node objects.
+type SignalError struct {
+	PlanID    string      `json:"planID"`
+	Reason    string      `json:"reason"`
+	Message   string      `json:"message"`
+	Timestamp metav1.Time `json:"timestamp"`
+}
+
+// truncate returns s truncated to max bytes, appending "..." when truncated.
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max-3] + "..."
+}
+
+// writeSignalErrorAnnotation writes a SignalError as a JSON annotation on obj.
+// message is truncated before encoding to keep the annotation size bounded.
+// reason is a short constant (e.g. "FailedDownload") and is not truncated.
+func writeSignalErrorAnnotation(obj crcli.Object, planID, reason, message string) error {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	e := SignalError{
+		PlanID:    planID,
+		Reason:    reason,
+		Message:   truncate(message, maxMessageLen),
+		Timestamp: metav1.Now(),
+	}
+	raw, err := json.Marshal(e)
+	if err != nil {
+		return err
+	}
+	annotations[SignalErrorAnnotation] = string(raw)
+	obj.SetAnnotations(annotations)
+	return nil
+}
+
+// readSignalErrorAnnotation reads the SignalError annotation from obj and
+// returns "reason: message", or "" if absent or unparseable.
+func readSignalErrorAnnotation(obj crcli.Object) string {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return ""
+	}
+	raw, ok := annotations[SignalErrorAnnotation]
+	if !ok {
+		return ""
+	}
+	var e SignalError
+	if err := json.Unmarshal([]byte(raw), &e); err != nil {
+		return ""
+	}
+	return e.Reason + ": " + e.Message
+}
+
+// clearSignalErrorAnnotation removes the SignalError annotation from obj in-memory.
+func clearSignalErrorAnnotation(obj crcli.Object) {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return
+	}
+	delete(annotations, SignalErrorAnnotation)
+	obj.SetAnnotations(annotations)
+}

--- a/pkg/autopilot/controller/delegate/specialized.go
+++ b/pkg/autopilot/controller/delegate/specialized.go
@@ -75,6 +75,13 @@ func ControlNodeControllerDelegate(opts ...ControllerDelegateOption) ControllerD
 
 			return nil
 		},
+		readSignalErrorAnnotation,
+		func(_ context.Context, _ crcli.Client, obj crcli.Object, planID, reason, message string) error {
+			return writeSignalErrorAnnotation(obj, planID, reason, message)
+		},
+		func(_ context.Context, _ crcli.Client, obj crcli.Object) {
+			clearSignalErrorAnnotation(obj)
+		},
 	}
 
 	for _, opt := range opts {
@@ -128,6 +135,13 @@ func NodeControllerDelegate(opts ...ControllerDelegateOption) ControllerDelegate
 			}
 
 			return nil
+		},
+		readSignalErrorAnnotation,
+		func(_ context.Context, _ crcli.Client, obj crcli.Object, planID, reason, message string) error {
+			return writeSignalErrorAnnotation(obj, planID, reason, message)
+		},
+		func(_ context.Context, _ crcli.Client, obj crcli.Object) {
+			clearSignalErrorAnnotation(obj)
 		},
 	}
 

--- a/pkg/autopilot/controller/delegate/specialized_test.go
+++ b/pkg/autopilot/controller/delegate/specialized_test.go
@@ -4,12 +4,16 @@
 package delegate
 
 import (
-	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot/v1beta2"
-
+	"encoding/json"
+	"strings"
 	"testing"
+
+	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot/v1beta2"
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	crcli "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // TestNodeReady ensures that the delegate can identify when a worker node is
@@ -60,6 +64,128 @@ func TestNodeReady(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			assert.Equal(t, test.expectedReady, delegate.K0sUpdateReady(t.Context(), apv1beta2.PlanCommandK0sUpdateStatus{}, test.node))
+		})
+	}
+}
+
+func TestReadSignalError(t *testing.T) {
+	var tests = []struct {
+		name     string
+		obj      crcli.Object
+		delegate ControllerDelegate
+		expected string
+	}{
+		{
+			"ControlNodeWithErrorAnnotation",
+			&apv1beta2.ControlNode{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						SignalErrorAnnotation: `{"planID":"plan1","reason":"FailedDownload","message":"checksum mismatch","timestamp":"2024-01-01T00:00:00Z"}`,
+					},
+				},
+			},
+			ControlNodeControllerDelegate(),
+			"FailedDownload: checksum mismatch",
+		},
+		{
+			"ControlNodeNoAnnotation",
+			&apv1beta2.ControlNode{},
+			ControlNodeControllerDelegate(),
+			"",
+		},
+		{
+			"NodeWithErrorAnnotation",
+			&v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						SignalErrorAnnotation: `{"planID":"plan1","reason":"FailedDownload","message":"checksum mismatch","timestamp":"2024-01-01T00:00:00Z"}`,
+					},
+				},
+			},
+			NodeControllerDelegate(),
+			"FailedDownload: checksum mismatch",
+		},
+		{
+			"NodeNoAnnotation",
+			&v1.Node{},
+			NodeControllerDelegate(),
+			"",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, test.delegate.ReadSignalError(test.obj))
+		})
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	var tests = []struct {
+		name     string
+		input    string
+		max      int
+		expected string
+	}{
+		{"BelowLimit", "short", 10, "short"},
+		{"AtLimit", "exactly10!", 10, "exactly10!"},
+		{"OneOverLimit", "exactly10!x", 10, "exactly..."},
+		{"WellOverLimit", strings.Repeat("a", 100), 10, strings.Repeat("a", 7) + "..."},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := truncate(test.input, test.max)
+			assert.Equal(t, test.expected, got)
+			assert.LessOrEqual(t, len(got), test.max)
+		})
+	}
+}
+
+func TestWriteSignalErrorAnnotationTruncation(t *testing.T) {
+	longMessage := strings.Repeat("m", maxMessageLen+10)
+
+	for _, tc := range []struct {
+		name     string
+		obj      crcli.Object
+		delegate ControllerDelegate
+	}{
+		{"ControlNode", &apv1beta2.ControlNode{}, ControlNodeControllerDelegate()},
+		{"Node", &v1.Node{}, NodeControllerDelegate()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.delegate.WriteSignalError(t.Context(), nil, tc.obj, "plan1", "FailedDownload", longMessage)
+			assert.NoError(t, err)
+
+			raw, ok := tc.obj.GetAnnotations()[SignalErrorAnnotation]
+			assert.True(t, ok, "annotation should be set")
+
+			var e SignalError
+			assert.NoError(t, json.Unmarshal([]byte(raw), &e))
+			assert.Equal(t, "FailedDownload", e.Reason, "reason should be stored as-is")
+			assert.LessOrEqual(t, len(e.Message), maxMessageLen, "message should be truncated")
+			assert.True(t, strings.HasSuffix(e.Message, "..."), "truncated message should end with ...")
+		})
+	}
+}
+
+func TestClearSignalErrorAnnotation(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		obj      crcli.Object
+		delegate ControllerDelegate
+	}{
+		{"ControlNode", &apv1beta2.ControlNode{ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{SignalErrorAnnotation: `{"planID":"p","reason":"r","message":"m","timestamp":"2024-01-01T00:00:00Z"}`},
+		}}, ControlNodeControllerDelegate()},
+		{"Node", &v1.Node{ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{SignalErrorAnnotation: `{"planID":"p","reason":"r","message":"m","timestamp":"2024-01-01T00:00:00Z"}`},
+		}}, NodeControllerDelegate()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.delegate.ClearSignalError(t.Context(), nil, tc.obj)
+			_, ok := tc.obj.GetAnnotations()[SignalErrorAnnotation]
+			assert.False(t, ok, "annotation should be cleared")
 		})
 	}
 }

--- a/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/schedulable.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/schedulable.go
@@ -52,6 +52,10 @@ func (aup *airgapupdate) Schedulable(ctx context.Context, planID string, cmd apv
 	logger.Infof("Sending signaling to node='%s'", nextForSignal.Name)
 
 	signalNodeCopy := signalNodeDelegate.DeepCopy(signalNode)
+
+	// Clear any stale error annotation from a previous attempt before sending the new signal.
+	signalNodeDelegate.ClearSignalError(ctx, aup.client, signalNodeCopy)
+
 	signalNodeCommandBuilder, err := signalNodeAirgapUpdateCommandBuilder(signalNodeCopy, cmd, status)
 	if err != nil {
 		logger.Warnf("Unable to build signal node content: %v", err)

--- a/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/schedulable_test.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/schedulable_test.go
@@ -19,6 +19,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apimruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	crcli "sigs.k8s.io/controller-runtime/pkg/client"
 	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -132,6 +133,55 @@ func TestSchedulable(t *testing.T) {
 				apv1beta2.NewPlanCommandTargetStatus("worker0", appc.SignalSent),
 			},
 		},
+
+		// Ensures that when a new signal is sent to a worker node that had a stale error annotation,
+		// the error annotation is cleared before sending the signal.
+		{
+			"NodeErrorAnnotationClearedOnNewSignal",
+			[]crcli.Object{
+				&corev1.Node{
+					TypeMeta: metav1.TypeMeta{Kind: "Node", APIVersion: "v1"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "worker0",
+						Labels: map[string]string{corev1.LabelOSStable: "theOS", corev1.LabelArchStable: "theArch"},
+						Annotations: map[string]string{
+							"k0sproject.io/autopilot-last-error": `{"planID":"oldplan","reason":"FailedDownload","message":"stale error","timestamp":"2024-01-01T00:00:00Z"}`,
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+					},
+				},
+			},
+			apv1beta2.PlanCommand{
+				AirgapUpdate: &apv1beta2.PlanCommandAirgapUpdate{
+					Version: "v99.99.99",
+					Platforms: apv1beta2.PlanPlatformResourceURLMap{
+						"theOS-theArch": {URL: "https://k0s.example.com/downloads/k0s-v99.99.99-theOS-theArch"},
+					},
+					Workers: apv1beta2.PlanCommandTarget{
+						Discovery: apv1beta2.PlanCommandTargetDiscovery{
+							Static: &apv1beta2.PlanCommandTargetDiscoveryStatic{Nodes: []string{"worker0"}},
+						},
+						Limits: apv1beta2.PlanCommandTargetLimits{Concurrent: 1},
+					},
+				},
+			},
+			apv1beta2.PlanCommandStatus{
+				ID:    123,
+				State: appc.PlanSchedulable,
+				AirgapUpdate: &apv1beta2.PlanCommandAirgapUpdateStatus{
+					Workers: []apv1beta2.PlanCommandTargetStatus{
+						apv1beta2.NewPlanCommandTargetStatus("worker0", appc.SignalPending),
+					},
+				},
+			},
+			appc.PlanSchedulableWait,
+			false,
+			[]apv1beta2.PlanCommandTargetStatus{
+				apv1beta2.NewPlanCommandTargetStatus("worker0", appc.SignalSent),
+			},
+		},
 	}
 
 	scheme := apimruntime.NewScheme()
@@ -159,6 +209,13 @@ func TestSchedulable(t *testing.T) {
 			assert.Equal(t, test.expectedRetry, retry)
 			assert.NoError(t, err)
 			assert.True(t, cmp.Equal(test.expectedPlanStatusWorkers, test.status.AirgapUpdate.Workers, cmpopts.IgnoreFields(apv1beta2.PlanCommandTargetStatus{}, "LastUpdatedTimestamp")))
+
+			if test.name == "NodeErrorAnnotationClearedOnNewSignal" {
+				node := &corev1.Node{}
+				assert.NoError(t, client.Get(ctx, types.NamespacedName{Name: "worker0"}, node))
+				_, hasAnnotation := node.GetAnnotations()["k0sproject.io/autopilot-last-error"]
+				assert.False(t, hasAnnotation)
+			}
 		})
 	}
 }

--- a/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/schedulablewait.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/schedulablewait.go
@@ -5,6 +5,7 @@ package airgapupdate
 
 import (
 	"context"
+	"strings"
 
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot/v1beta2"
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
@@ -30,6 +31,7 @@ func (aup *airgapupdate) SchedulableWait(ctx context.Context, planID string, cmd
 
 	if appku.IsNotRecoverable(status.AirgapUpdate.Workers) {
 		logger.Info("Plan is non-recoverable due to apply failure")
+		status.Description = buildFailureSummary(status.AirgapUpdate.Workers)
 		return appc.PlanApplyFailed, false, nil
 	}
 
@@ -76,6 +78,7 @@ func (aup *airgapupdate) reconcileSignalNodeStatusTarget(ctx context.Context, pl
 
 						if signalData.Status.Status == apsigcomm.Failed || signalData.Status.Status == apsigcomm.FailedDownload {
 							signalNodes[i].State = appc.SignalApplyFailed
+							signalNodes[i].Description = delegate.ReadSignalError(signalNode)
 						}
 
 						if signalData.Status.Status == apsigcomm.Completed {
@@ -128,4 +131,18 @@ func countPlanCommandTargetStatus(nodes []apv1beta2.PlanCommandTargetStatus) (pe
 	}
 
 	return
+}
+
+// buildFailureSummary collects per-node descriptions from failed nodes into a single summary string,
+// e.g. "worker0: FailedDownload: checksum mismatch; worker1: FailedDownload: checksum mismatch".
+func buildFailureSummary(groups ...[]apv1beta2.PlanCommandTargetStatus) string {
+	var parts []string
+	for _, group := range groups {
+		for _, node := range group {
+			if node.State == appc.SignalApplyFailed && node.Description != "" {
+				parts = append(parts, node.Name+": "+node.Description)
+			}
+		}
+	}
+	return strings.Join(parts, "; ")
 }

--- a/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/schedulablewait_test.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/airgapupdate/schedulablewait_test.go
@@ -36,13 +36,15 @@ func signalNodeStatusDataAnnotations(sd apsigv2.SignalData) map[string]string {
 // to `Schedulable` only under certain conditions.
 func TestSchedulableWait(t *testing.T) {
 	var tests = []struct {
-		name                      string
-		objects                   []crcli.Object
-		command                   apv1beta2.PlanCommand
-		status                    apv1beta2.PlanCommandStatus
-		expectedNextState         apv1beta2.PlanStateType
-		expectedRetry             bool
-		expectedPlanStatusWorkers []apv1beta2.PlanCommandTargetStatus
+		name                       string
+		objects                    []crcli.Object
+		command                    apv1beta2.PlanCommand
+		status                     apv1beta2.PlanCommandStatus
+		expectedNextState          apv1beta2.PlanStateType
+		expectedRetry              bool
+		expectedPlanStatusWorkers  []apv1beta2.PlanCommandTargetStatus
+		expectedWorkerDescriptions map[string]string
+		expectedCommandDescription string
 	}{
 		// Worker-only tests
 
@@ -69,6 +71,8 @@ func TestSchedulableWait(t *testing.T) {
 				apv1beta2.NewPlanCommandTargetStatus("worker0", appc.SignalCompleted),
 				apv1beta2.NewPlanCommandTargetStatus("worker1", appc.SignalCompleted),
 			},
+			nil,
+			"",
 		},
 
 		// Ensures that if a node has been sent a signal, the state of the command should stay in
@@ -94,6 +98,8 @@ func TestSchedulableWait(t *testing.T) {
 				apv1beta2.NewPlanCommandTargetStatus("worker0", appc.SignalSent),
 				apv1beta2.NewPlanCommandTargetStatus("worker1", appc.SignalCompleted),
 			},
+			nil,
+			"",
 		},
 
 		// Ensures that if any of the nodes are in 'PendingSignal', they can be scheduled and the command
@@ -125,6 +131,8 @@ func TestSchedulableWait(t *testing.T) {
 				apv1beta2.NewPlanCommandTargetStatus("worker0", appc.SignalPending),
 				apv1beta2.NewPlanCommandTargetStatus("worker1", appc.SignalCompleted),
 			},
+			nil,
+			"",
 		},
 
 		// Ensures that if worker concurrency is == 2 and only one worker is considered pending, then
@@ -158,6 +166,8 @@ func TestSchedulableWait(t *testing.T) {
 				apv1beta2.NewPlanCommandTargetStatus("worker1", appc.SignalPending),
 				apv1beta2.NewPlanCommandTargetStatus("worker2", appc.SignalCompleted),
 			},
+			nil,
+			"",
 		},
 
 		// Ensures that if a signal node status is different than what is known by
@@ -207,6 +217,8 @@ func TestSchedulableWait(t *testing.T) {
 			[]apv1beta2.PlanCommandTargetStatus{
 				apv1beta2.NewPlanCommandTargetStatus("worker0", appc.SignalSent),
 			},
+			nil,
+			"",
 		},
 
 		// Covers the scenario of a v1.Node that contains autopilot state that indicates that
@@ -251,6 +263,8 @@ func TestSchedulableWait(t *testing.T) {
 			[]apv1beta2.PlanCommandTargetStatus{
 				apv1beta2.NewPlanCommandTargetStatus("worker0", appc.SignalPending),
 			},
+			nil,
+			"",
 		},
 
 		// Covers the scenario of a v1.Node that contains autopilot state that indicates that
@@ -295,6 +309,8 @@ func TestSchedulableWait(t *testing.T) {
 			[]apv1beta2.PlanCommandTargetStatus{
 				apv1beta2.NewPlanCommandTargetStatus("worker0", appc.SignalCompleted),
 			},
+			nil,
+			"",
 		},
 
 		// Cover the scenario where a node fails to apply an update, and that the failure
@@ -345,6 +361,196 @@ func TestSchedulableWait(t *testing.T) {
 			[]apv1beta2.PlanCommandTargetStatus{
 				apv1beta2.NewPlanCommandTargetStatus("worker0", appc.SignalApplyFailed),
 			},
+			nil,
+			"",
+		},
+
+		// Cover the scenario where a worker node has a last-error annotation and fails.
+		// The worker's Description in plan status should be populated and status.Description
+		// should contain the summary.
+		{
+			"SignalNodeApplyFailureWorkerDescription",
+			[]crcli.Object{
+				&v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker0",
+						Annotations: func() map[string]string {
+							m := signalNodeStatusDataAnnotations(
+								apsigv2.SignalData{
+									PlanID:  "id123",
+									Created: "now",
+									Command: apsigv2.Command{
+										ID: new(int),
+										AirgapUpdate: &apsigv2.CommandAirgapUpdate{
+											URL:     "https://foo.bar.baz/download.tar.gz",
+											Version: "v1.2.3",
+										},
+									},
+									Status: &apsigv2.Status{
+										Status:    apsigcomm.FailedDownload,
+										Timestamp: "now",
+									},
+								},
+							)
+							m["k0sproject.io/autopilot-last-error"] = `{"planID":"id123","reason":"FailedDownload","message":"checksum mismatch","timestamp":"2024-01-01T00:00:00Z"}`
+							return m
+						}(),
+					},
+					TypeMeta: metav1.TypeMeta{Kind: "Node", APIVersion: "v1"},
+				},
+			},
+			apv1beta2.PlanCommand{
+				AirgapUpdate: &apv1beta2.PlanCommandAirgapUpdate{},
+			},
+			apv1beta2.PlanCommandStatus{
+				State: appc.PlanSchedulableWait,
+				AirgapUpdate: &apv1beta2.PlanCommandAirgapUpdateStatus{
+					Workers: []apv1beta2.PlanCommandTargetStatus{
+						apv1beta2.NewPlanCommandTargetStatus("worker0", appc.SignalSent),
+					},
+				},
+			},
+			appc.PlanApplyFailed,
+			false,
+			[]apv1beta2.PlanCommandTargetStatus{
+				{Name: "worker0", State: appc.SignalApplyFailed, Description: "FailedDownload: checksum mismatch"},
+			},
+			map[string]string{"worker0": "FailedDownload: checksum mismatch"},
+			"worker0: FailedDownload: checksum mismatch",
+		},
+
+		// Cover the scenario where a worker fails but has no last-error annotation.
+		// Description should be empty.
+		{
+			"SignalNodeApplyFailureNoErrorDetail",
+			[]crcli.Object{
+				&v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker0",
+						Annotations: signalNodeStatusDataAnnotations(
+							apsigv2.SignalData{
+								PlanID:  "id123",
+								Created: "now",
+								Command: apsigv2.Command{
+									ID: new(int),
+									AirgapUpdate: &apsigv2.CommandAirgapUpdate{
+										URL:     "https://foo.bar.baz/download.tar.gz",
+										Version: "v1.2.3",
+									},
+								},
+								Status: &apsigv2.Status{
+									Status:    apsigcomm.Failed,
+									Timestamp: "now",
+								},
+							},
+						),
+					},
+					TypeMeta: metav1.TypeMeta{Kind: "Node", APIVersion: "v1"},
+				},
+			},
+			apv1beta2.PlanCommand{
+				AirgapUpdate: &apv1beta2.PlanCommandAirgapUpdate{},
+			},
+			apv1beta2.PlanCommandStatus{
+				State: appc.PlanSchedulableWait,
+				AirgapUpdate: &apv1beta2.PlanCommandAirgapUpdateStatus{
+					Workers: []apv1beta2.PlanCommandTargetStatus{
+						apv1beta2.NewPlanCommandTargetStatus("worker0", appc.SignalSent),
+					},
+				},
+			},
+			appc.PlanApplyFailed,
+			false,
+			[]apv1beta2.PlanCommandTargetStatus{
+				{Name: "worker0", State: appc.SignalApplyFailed, Description: ""},
+			},
+			nil,
+			"",
+		},
+
+		// Cover the scenario where multiple worker nodes fail with error annotations.
+		// The command description should contain a summary of all failures.
+		{
+			"SignalNodeApplyFailureMultiWorkerDescription",
+			[]crcli.Object{
+				&v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker0",
+						Annotations: func() map[string]string {
+							m := signalNodeStatusDataAnnotations(
+								apsigv2.SignalData{
+									PlanID:  "id123",
+									Created: "now",
+									Command: apsigv2.Command{
+										ID: new(int),
+										AirgapUpdate: &apsigv2.CommandAirgapUpdate{
+											URL:     "https://foo.bar.baz/download.tar.gz",
+											Version: "v1.2.3",
+										},
+									},
+									Status: &apsigv2.Status{
+										Status:    apsigcomm.FailedDownload,
+										Timestamp: "now",
+									},
+								},
+							)
+							m["k0sproject.io/autopilot-last-error"] = `{"planID":"id123","reason":"FailedDownload","message":"checksum mismatch","timestamp":"2024-01-01T00:00:00Z"}`
+							return m
+						}(),
+					},
+					TypeMeta: metav1.TypeMeta{Kind: "Node", APIVersion: "v1"},
+				},
+				&v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker1",
+						Annotations: func() map[string]string {
+							m := signalNodeStatusDataAnnotations(
+								apsigv2.SignalData{
+									PlanID:  "id123",
+									Created: "now",
+									Command: apsigv2.Command{
+										ID: new(int),
+										AirgapUpdate: &apsigv2.CommandAirgapUpdate{
+											URL:     "https://foo.bar.baz/download.tar.gz",
+											Version: "v1.2.3",
+										},
+									},
+									Status: &apsigv2.Status{
+										Status:    apsigcomm.FailedDownload,
+										Timestamp: "now",
+									},
+								},
+							)
+							m["k0sproject.io/autopilot-last-error"] = `{"planID":"id123","reason":"FailedDownload","message":"disk full","timestamp":"2024-01-01T00:00:00Z"}`
+							return m
+						}(),
+					},
+					TypeMeta: metav1.TypeMeta{Kind: "Node", APIVersion: "v1"},
+				},
+			},
+			apv1beta2.PlanCommand{
+				AirgapUpdate: &apv1beta2.PlanCommandAirgapUpdate{},
+			},
+			apv1beta2.PlanCommandStatus{
+				State: appc.PlanSchedulableWait,
+				AirgapUpdate: &apv1beta2.PlanCommandAirgapUpdateStatus{
+					Workers: []apv1beta2.PlanCommandTargetStatus{
+						apv1beta2.NewPlanCommandTargetStatus("worker0", appc.SignalSent),
+						apv1beta2.NewPlanCommandTargetStatus("worker1", appc.SignalSent),
+					},
+				},
+			},
+			appc.PlanApplyFailed,
+			false,
+			[]apv1beta2.PlanCommandTargetStatus{
+				{Name: "worker0", State: appc.SignalApplyFailed, Description: "FailedDownload: checksum mismatch"},
+				{Name: "worker1", State: appc.SignalApplyFailed, Description: "FailedDownload: disk full"},
+			},
+			map[string]string{
+				"worker0": "FailedDownload: checksum mismatch",
+				"worker1": "FailedDownload: disk full",
+			},
+			"worker0: FailedDownload: checksum mismatch; worker1: FailedDownload: disk full",
 		},
 	}
 
@@ -374,6 +580,12 @@ func TestSchedulableWait(t *testing.T) {
 			assert.Equal(t, test.expectedRetry, retry)
 			assert.NoError(t, err)
 			assert.True(t, cmp.Equal(test.expectedPlanStatusWorkers, test.status.AirgapUpdate.Workers, cmpopts.IgnoreFields(apv1beta2.PlanCommandTargetStatus{}, "LastUpdatedTimestamp")))
+			for _, worker := range test.status.AirgapUpdate.Workers {
+				if test.expectedWorkerDescriptions != nil {
+					assert.Equal(t, test.expectedWorkerDescriptions[worker.Name], worker.Description)
+				}
+			}
+			assert.Equal(t, test.expectedCommandDescription, test.status.Description)
 		})
 	}
 }

--- a/pkg/autopilot/controller/plans/cmdprovider/k0supdate/schedulable.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/k0supdate/schedulable.go
@@ -78,6 +78,10 @@ func (kp *k0supdate) Schedulable(ctx context.Context, planID string, cmd apv1bet
 	// disagree. This target state will move to `IncompleteTargets` in this case.
 
 	signalNodeCopy := signalNodeDelegate.DeepCopy(signalNode)
+
+	// Clear any stale error annotation from a previous attempt before sending the new signal.
+	signalNodeDelegate.ClearSignalError(ctx, kp.client, signalNodeCopy)
+
 	signalNodeCommandBuilder, err := signalNodeK0sUpdateCommandBuilder(signalNodeCopy, cmd, status)
 	if err != nil {
 		logger.Warnf("Unable to build signal node content: %v", err)

--- a/pkg/autopilot/controller/plans/cmdprovider/k0supdate/schedulable_test.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/k0supdate/schedulable_test.go
@@ -20,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apimruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -204,10 +205,114 @@ func TestSchedulable(t *testing.T) {
 			nil,
 			true,
 		},
+
+		// Ensures that a stale error annotation on a ControlNode is cleared before the new signal is sent.
+		{
+			"ControlNodeErrorClearedOnNewSignal",
+			[]crcli.Object{
+				&apv1beta2.ControlNode{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ControlNode",
+						APIVersion: "autopilot.k0sproject.io/v1beta2",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "controller0",
+						Labels: map[string]string{corev1.LabelOSStable: "theOS", corev1.LabelArchStable: "theArch"},
+						Annotations: map[string]string{
+							apdel.SignalErrorAnnotation: `{"planID":"oldplan","reason":"FailedDownload","message":"stale error","timestamp":"2024-01-01T00:00:00Z"}`,
+						},
+					},
+				},
+			},
+			apv1beta2.PlanCommand{
+				K0sUpdate: &apv1beta2.PlanCommandK0sUpdate{
+					Version: "v99.99.99",
+					Platforms: apv1beta2.PlanPlatformResourceURLMap{
+						"theOS-theArch": {URL: "https://k0s.example.com/downloads/k0s-v99.99.99-theOS-theArch"},
+					},
+					Targets: apv1beta2.PlanCommandTargets{
+						Controllers: apv1beta2.PlanCommandTarget{
+							Discovery: apv1beta2.PlanCommandTargetDiscovery{
+								Static: &apv1beta2.PlanCommandTargetDiscoveryStatic{Nodes: []string{"controller0"}},
+							},
+						},
+					},
+				},
+			},
+			apv1beta2.PlanCommandStatus{
+				ID:    123,
+				State: appc.PlanSchedulable,
+				K0sUpdate: &apv1beta2.PlanCommandK0sUpdateStatus{
+					Controllers: []apv1beta2.PlanCommandTargetStatus{
+						apv1beta2.NewPlanCommandTargetStatus("controller0", appc.SignalPending),
+					},
+				},
+			},
+			appc.PlanSchedulableWait,
+			false,
+			[]apv1beta2.PlanCommandTargetStatus{
+				apv1beta2.NewPlanCommandTargetStatus("controller0", appc.SignalSent),
+			},
+			nil,
+			false,
+		},
+
+		// Ensures that a stale last-error annotation on a Node is cleared before the new signal is sent.
+		{
+			"NodeErrorAnnotationClearedOnNewSignal",
+			[]crcli.Object{
+				&corev1.Node{
+					TypeMeta: metav1.TypeMeta{Kind: "Node", APIVersion: "v1"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "worker0",
+						Labels: map[string]string{corev1.LabelOSStable: "theOS", corev1.LabelArchStable: "theArch"},
+						Annotations: map[string]string{
+							"k0sproject.io/autopilot-last-error": `{"planID":"oldplan","reason":"FailedDownload","message":"stale error","timestamp":"2024-01-01T00:00:00Z"}`,
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+					},
+				},
+			},
+			apv1beta2.PlanCommand{
+				K0sUpdate: &apv1beta2.PlanCommandK0sUpdate{
+					Version: "v99.99.99",
+					Platforms: apv1beta2.PlanPlatformResourceURLMap{
+						"theOS-theArch": {URL: "https://k0s.example.com/downloads/k0s-v99.99.99-theOS-theArch"},
+					},
+					Targets: apv1beta2.PlanCommandTargets{
+						Workers: apv1beta2.PlanCommandTarget{
+							Discovery: apv1beta2.PlanCommandTargetDiscovery{
+								Static: &apv1beta2.PlanCommandTargetDiscoveryStatic{Nodes: []string{"worker0"}},
+							},
+							Limits: apv1beta2.PlanCommandTargetLimits{Concurrent: 1},
+						},
+					},
+				},
+			},
+			apv1beta2.PlanCommandStatus{
+				ID:    123,
+				State: appc.PlanSchedulable,
+				K0sUpdate: &apv1beta2.PlanCommandK0sUpdateStatus{
+					Workers: []apv1beta2.PlanCommandTargetStatus{
+						apv1beta2.NewPlanCommandTargetStatus("worker0", appc.SignalPending),
+					},
+				},
+			},
+			appc.PlanSchedulableWait,
+			false,
+			nil,
+			[]apv1beta2.PlanCommandTargetStatus{
+				apv1beta2.NewPlanCommandTargetStatus("worker0", appc.SignalSent),
+			},
+			false,
+		},
 	}
 
 	scheme := apimruntime.NewScheme()
 	assert.NoError(t, apscheme.AddToScheme(scheme))
+	assert.NoError(t, corev1.AddToScheme(scheme))
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -249,6 +354,19 @@ func TestSchedulable(t *testing.T) {
 
 			assert.True(t, cmp.Equal(test.expectedPlanStatusControllers, test.status.K0sUpdate.Controllers, cmpopts.IgnoreFields(apv1beta2.PlanCommandTargetStatus{}, "LastUpdatedTimestamp")))
 			assert.True(t, cmp.Equal(test.expectedPlanStatusWorkers, test.status.K0sUpdate.Workers, cmpopts.IgnoreFields(apv1beta2.PlanCommandTargetStatus{}, "LastUpdatedTimestamp")))
+
+			if test.name == "ControlNodeErrorClearedOnNewSignal" {
+				cn := &apv1beta2.ControlNode{}
+				assert.NoError(t, client.Get(ctx, types.NamespacedName{Name: "controller0"}, cn))
+				_, hasAnnotation := cn.GetAnnotations()[apdel.SignalErrorAnnotation]
+				assert.False(t, hasAnnotation, "error annotation should be cleared before new signal")
+			}
+			if test.name == "NodeErrorAnnotationClearedOnNewSignal" {
+				node := &corev1.Node{}
+				assert.NoError(t, client.Get(ctx, types.NamespacedName{Name: "worker0"}, node))
+				_, hasAnnotation := node.GetAnnotations()[apdel.SignalErrorAnnotation]
+				assert.False(t, hasAnnotation)
+			}
 
 		})
 	}

--- a/pkg/autopilot/controller/plans/cmdprovider/k0supdate/schedulablewait.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/k0supdate/schedulablewait.go
@@ -6,6 +6,7 @@ package k0supdate
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot/v1beta2"
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
@@ -33,6 +34,7 @@ func (kp *k0supdate) SchedulableWait(ctx context.Context, planID string, cmd apv
 
 	if appku.IsNotRecoverable(status.K0sUpdate.Controllers, status.K0sUpdate.Workers) {
 		logger.Info("Plan is non-recoverable due to apply failure")
+		status.Description = buildFailureSummary(status.K0sUpdate.Controllers, status.K0sUpdate.Workers)
 		return appc.PlanApplyFailed, false, nil
 	}
 
@@ -118,6 +120,7 @@ func (kp *k0supdate) reconcileSignalNodeStatusTarget(ctx context.Context, planID
 
 						if signalData.Status.Status == apsigcomm.Failed || signalData.Status.Status == apsigcomm.FailedDownload {
 							signalNodes[i].State = appc.SignalApplyFailed
+							signalNodes[i].Description = delegate.ReadSignalError(signalNode)
 						}
 
 						if signalData.Status.Status == apsigcomm.Completed {
@@ -179,4 +182,18 @@ func countPlanCommandTargetStatus(nodes []apv1beta2.PlanCommandTargetStatus) (pe
 	}
 
 	return
+}
+
+// buildFailureSummary collects per-node descriptions from failed nodes into a single summary string,
+// e.g. "controller0: FailedDownload: checksum mismatch; worker0: FailedDownload: checksum mismatch".
+func buildFailureSummary(groups ...[]apv1beta2.PlanCommandTargetStatus) string {
+	var parts []string
+	for _, group := range groups {
+		for _, node := range group {
+			if node.State == appc.SignalApplyFailed && node.Description != "" {
+				parts = append(parts, node.Name+": "+node.Description)
+			}
+		}
+	}
+	return strings.Join(parts, "; ")
 }

--- a/pkg/autopilot/controller/plans/cmdprovider/k0supdate/schedulablewait_test.go
+++ b/pkg/autopilot/controller/plans/cmdprovider/k0supdate/schedulablewait_test.go
@@ -36,14 +36,16 @@ func signalNodeStatusDataAnnotations(sd apsigv2.SignalData) map[string]string {
 // to `Schedulable` only under certain conditions.
 func TestSchedulableWait(t *testing.T) {
 	var tests = []struct {
-		name                          string
-		objects                       []crcli.Object
-		command                       apv1beta2.PlanCommand
-		status                        apv1beta2.PlanCommandStatus
-		expectedNextState             apv1beta2.PlanStateType
-		expectedRetry                 bool
-		expectedPlanStatusControllers []apv1beta2.PlanCommandTargetStatus
-		expectedPlanStatusWorkers     []apv1beta2.PlanCommandTargetStatus
+		name                           string
+		objects                        []crcli.Object
+		command                        apv1beta2.PlanCommand
+		status                         apv1beta2.PlanCommandStatus
+		expectedNextState              apv1beta2.PlanStateType
+		expectedRetry                  bool
+		expectedPlanStatusControllers  []apv1beta2.PlanCommandTargetStatus
+		expectedPlanStatusWorkers      []apv1beta2.PlanCommandTargetStatus
+		expectedControllerDescriptions map[string]string // name -> Description
+		expectedCommandDescription     string
 	}{
 		// Controller-only tests
 
@@ -71,6 +73,8 @@ func TestSchedulableWait(t *testing.T) {
 				apv1beta2.NewPlanCommandTargetStatus("controller1", appc.SignalCompleted),
 			},
 			nil,
+			nil,
+			"",
 		},
 
 		// Ensures that if a node has been sent a signal, the state of the command should stay in
@@ -96,6 +100,8 @@ func TestSchedulableWait(t *testing.T) {
 				apv1beta2.NewPlanCommandTargetStatus("controller1", appc.SignalCompleted),
 			},
 			nil,
+			nil,
+			"",
 		},
 
 		// Ensures that if any of the nodes are in 'PendingSignal', they can be scheduled and the command
@@ -122,6 +128,8 @@ func TestSchedulableWait(t *testing.T) {
 				apv1beta2.NewPlanCommandTargetStatus("controller1", appc.SignalCompleted),
 			},
 			nil,
+			nil,
+			"",
 		},
 
 		// Worker-only tests
@@ -150,6 +158,8 @@ func TestSchedulableWait(t *testing.T) {
 				apv1beta2.NewPlanCommandTargetStatus("worker0", appc.SignalCompleted),
 				apv1beta2.NewPlanCommandTargetStatus("worker1", appc.SignalCompleted),
 			},
+			nil,
+			"",
 		},
 
 		// Ensures that if a node has been sent a signal, the state of the command should stay in
@@ -176,6 +186,8 @@ func TestSchedulableWait(t *testing.T) {
 				apv1beta2.NewPlanCommandTargetStatus("worker0", appc.SignalSent),
 				apv1beta2.NewPlanCommandTargetStatus("worker1", appc.SignalCompleted),
 			},
+			nil,
+			"",
 		},
 
 		// Ensures that if any of the nodes are in 'PendingSignal', they can be scheduled and the command
@@ -210,6 +222,8 @@ func TestSchedulableWait(t *testing.T) {
 				apv1beta2.NewPlanCommandTargetStatus("worker0", appc.SignalPending),
 				apv1beta2.NewPlanCommandTargetStatus("worker1", appc.SignalCompleted),
 			},
+			nil,
+			"",
 		},
 
 		// Ensures that if worker concurrency is == 2 and only one worker is considered pending, then
@@ -246,6 +260,8 @@ func TestSchedulableWait(t *testing.T) {
 				apv1beta2.NewPlanCommandTargetStatus("worker1", appc.SignalPending),
 				apv1beta2.NewPlanCommandTargetStatus("worker2", appc.SignalCompleted),
 			},
+			nil,
+			"",
 		},
 
 		// Ensures that if a signal node status is different than what is known by
@@ -297,6 +313,8 @@ func TestSchedulableWait(t *testing.T) {
 				apv1beta2.NewPlanCommandTargetStatus("controller0", appc.SignalCompleted),
 			},
 			nil,
+			nil,
+			"",
 		},
 
 		// Cover the scenario where a node fails to apply an update, and that the failure
@@ -348,6 +366,227 @@ func TestSchedulableWait(t *testing.T) {
 				apv1beta2.NewPlanCommandTargetStatus("controller0", appc.SignalApplyFailed),
 			},
 			nil,
+			nil,
+			"",
+		},
+
+		// Case 1: Controller with FailedDownload and lastSignalError set
+		{
+			"SignalNodeApplyFailureControllerDescription",
+			[]crcli.Object{
+				&apv1beta2.ControlNode{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "controller0",
+						Annotations: func() map[string]string {
+							m := signalNodeStatusDataAnnotations(
+								apsigv2.SignalData{
+									PlanID:  "id123",
+									Created: "now",
+									Command: apsigv2.Command{
+										ID: new(int),
+										K0sUpdate: &apsigv2.CommandK0sUpdate{
+											URL:     "https://foo.bar.baz/download.tar.gz",
+											Version: "v1.2.3",
+										},
+									},
+									Status: &apsigv2.Status{
+										Status:    apsigcomm.FailedDownload,
+										Timestamp: "now",
+									},
+								},
+							)
+							m[apdel.SignalErrorAnnotation] = `{"planID":"id123","reason":"FailedDownload","message":"checksum mismatch","timestamp":"2024-01-01T00:00:00Z"}`
+							return m
+						}(),
+					},
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ControlNode",
+						APIVersion: "autopilot.k0sproject.io/v1beta2",
+					},
+				},
+			},
+			apv1beta2.PlanCommand{
+				K0sUpdate: &apv1beta2.PlanCommandK0sUpdate{},
+			},
+			apv1beta2.PlanCommandStatus{
+				State: appc.PlanSchedulableWait,
+				K0sUpdate: &apv1beta2.PlanCommandK0sUpdateStatus{
+					Controllers: []apv1beta2.PlanCommandTargetStatus{
+						apv1beta2.NewPlanCommandTargetStatus("controller0", appc.SignalSent),
+					},
+				},
+			},
+			appc.PlanApplyFailed,
+			false,
+			[]apv1beta2.PlanCommandTargetStatus{
+				{Name: "controller0", State: appc.SignalApplyFailed, Description: "FailedDownload: checksum mismatch"},
+			},
+			nil,
+			map[string]string{"controller0": "FailedDownload: checksum mismatch"},
+			"controller0: FailedDownload: checksum mismatch",
+		},
+
+		// Case 2: Worker with FailedDownload and last-error annotation
+		{
+			"SignalNodeApplyFailureWorkerDescription",
+			[]crcli.Object{
+				&v1.Node{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Node",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker0",
+						Annotations: func() map[string]string {
+							m := signalNodeStatusDataAnnotations(apsigv2.SignalData{
+								PlanID:  "id123",
+								Created: "now",
+								Command: apsigv2.Command{
+									ID: new(int),
+									K0sUpdate: &apsigv2.CommandK0sUpdate{
+										URL:     "https://foo.bar.baz/download.tar.gz",
+										Version: "v1.2.3",
+									},
+								},
+								Status: &apsigv2.Status{
+									Status:    apsigcomm.FailedDownload,
+									Timestamp: "now",
+								},
+							})
+							m[apdel.SignalErrorAnnotation] = `{"planID":"id123","reason":"FailedDownload","message":"checksum mismatch","timestamp":"2024-01-01T00:00:00Z"}`
+							return m
+						}(),
+					},
+				},
+			},
+			apv1beta2.PlanCommand{
+				K0sUpdate: &apv1beta2.PlanCommandK0sUpdate{},
+			},
+			apv1beta2.PlanCommandStatus{
+				State: appc.PlanSchedulableWait,
+				K0sUpdate: &apv1beta2.PlanCommandK0sUpdateStatus{
+					Workers: []apv1beta2.PlanCommandTargetStatus{
+						apv1beta2.NewPlanCommandTargetStatus("worker0", appc.SignalSent),
+					},
+				},
+			},
+			appc.PlanApplyFailed,
+			false,
+			nil,
+			[]apv1beta2.PlanCommandTargetStatus{
+				{Name: "worker0", State: appc.SignalApplyFailed, Description: "FailedDownload: checksum mismatch"},
+			},
+			map[string]string{"worker0": "FailedDownload: checksum mismatch"},
+			"worker0: FailedDownload: checksum mismatch",
+		},
+
+		// Case 3: Two nodes both fail — command Description has both
+		{
+			"SignalNodeApplyFailureMultiNodeDescription",
+			[]crcli.Object{
+				&apv1beta2.ControlNode{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "controller0",
+						Annotations: func() map[string]string {
+							m := signalNodeStatusDataAnnotations(apsigv2.SignalData{
+								PlanID:  "id123",
+								Created: "now",
+								Command: apsigv2.Command{
+									ID:        new(int),
+									K0sUpdate: &apsigv2.CommandK0sUpdate{URL: "https://foo.bar.baz/download.tar.gz", Version: "v1.2.3"},
+								},
+								Status: &apsigv2.Status{Status: apsigcomm.FailedDownload, Timestamp: "now"},
+							})
+							m[apdel.SignalErrorAnnotation] = `{"planID":"id123","reason":"FailedDownload","message":"checksum mismatch","timestamp":"2024-01-01T00:00:00Z"}`
+							return m
+						}(),
+					},
+					TypeMeta: metav1.TypeMeta{Kind: "ControlNode", APIVersion: "autopilot.k0sproject.io/v1beta2"},
+				},
+				&v1.Node{
+					TypeMeta: metav1.TypeMeta{Kind: "Node", APIVersion: "v1"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker0",
+						Annotations: func() map[string]string {
+							m := signalNodeStatusDataAnnotations(apsigv2.SignalData{
+								PlanID: "id123", Created: "now",
+								Command: apsigv2.Command{
+									ID:        new(int),
+									K0sUpdate: &apsigv2.CommandK0sUpdate{URL: "https://foo.bar.baz/download.tar.gz", Version: "v1.2.3"},
+								},
+								Status: &apsigv2.Status{Status: apsigcomm.FailedDownload, Timestamp: "now"},
+							})
+							m[apdel.SignalErrorAnnotation] = `{"planID":"id123","reason":"FailedDownload","message":"checksum mismatch","timestamp":"2024-01-01T00:00:00Z"}`
+							return m
+						}(),
+					},
+				},
+			},
+			apv1beta2.PlanCommand{K0sUpdate: &apv1beta2.PlanCommandK0sUpdate{}},
+			apv1beta2.PlanCommandStatus{
+				State: appc.PlanSchedulableWait,
+				K0sUpdate: &apv1beta2.PlanCommandK0sUpdateStatus{
+					Controllers: []apv1beta2.PlanCommandTargetStatus{
+						apv1beta2.NewPlanCommandTargetStatus("controller0", appc.SignalSent),
+					},
+					Workers: []apv1beta2.PlanCommandTargetStatus{
+						apv1beta2.NewPlanCommandTargetStatus("worker0", appc.SignalSent),
+					},
+				},
+			},
+			appc.PlanApplyFailed,
+			false,
+			[]apv1beta2.PlanCommandTargetStatus{
+				{Name: "controller0", State: appc.SignalApplyFailed, Description: "FailedDownload: checksum mismatch"},
+			},
+			[]apv1beta2.PlanCommandTargetStatus{
+				{Name: "worker0", State: appc.SignalApplyFailed, Description: "FailedDownload: checksum mismatch"},
+			},
+			map[string]string{
+				"controller0": "FailedDownload: checksum mismatch",
+				"worker0":     "FailedDownload: checksum mismatch",
+			},
+			"controller0: FailedDownload: checksum mismatch",
+		},
+
+		// Case 4: FailedDownload but no error detail — Description stays empty
+		{
+			"SignalNodeApplyFailureNoErrorDetail",
+			[]crcli.Object{
+				&apv1beta2.ControlNode{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "controller0",
+						Annotations: signalNodeStatusDataAnnotations(apsigv2.SignalData{
+							PlanID:  "id123",
+							Created: "now",
+							Command: apsigv2.Command{
+								ID:        new(int),
+								K0sUpdate: &apsigv2.CommandK0sUpdate{URL: "https://foo.bar.baz/download.tar.gz", Version: "v1.2.3"},
+							},
+							Status: &apsigv2.Status{Status: apsigcomm.FailedDownload, Timestamp: "now"},
+						}),
+					},
+					TypeMeta: metav1.TypeMeta{Kind: "ControlNode", APIVersion: "autopilot.k0sproject.io/v1beta2"},
+					// No error annotation — simulates failed WriteSignalError
+				},
+			},
+			apv1beta2.PlanCommand{K0sUpdate: &apv1beta2.PlanCommandK0sUpdate{}},
+			apv1beta2.PlanCommandStatus{
+				State: appc.PlanSchedulableWait,
+				K0sUpdate: &apv1beta2.PlanCommandK0sUpdateStatus{
+					Controllers: []apv1beta2.PlanCommandTargetStatus{
+						apv1beta2.NewPlanCommandTargetStatus("controller0", appc.SignalSent),
+					},
+				},
+			},
+			appc.PlanApplyFailed,
+			false,
+			[]apv1beta2.PlanCommandTargetStatus{
+				{Name: "controller0", State: appc.SignalApplyFailed, Description: ""},
+			},
+			nil,
+			nil,
+			"",
 		},
 
 		// Controller + worker combinations
@@ -395,6 +634,8 @@ func TestSchedulableWait(t *testing.T) {
 				apv1beta2.NewPlanCommandTargetStatus("worker1", appc.SignalPending),
 				apv1beta2.NewPlanCommandTargetStatus("worker2", appc.SignalPending),
 			},
+			nil,
+			"",
 		},
 
 		// Ensure that if all controllers are completed, that the status transitions to `Schedulable`
@@ -440,6 +681,8 @@ func TestSchedulableWait(t *testing.T) {
 				apv1beta2.NewPlanCommandTargetStatus("worker1", appc.SignalPending),
 				apv1beta2.NewPlanCommandTargetStatus("worker2", appc.SignalPending),
 			},
+			nil,
+			"",
 		},
 
 		// Covers the scenario of a v1.Node that contains autopilot state that indicates that
@@ -487,6 +730,8 @@ func TestSchedulableWait(t *testing.T) {
 			[]apv1beta2.PlanCommandTargetStatus{
 				apv1beta2.NewPlanCommandTargetStatus("worker0", appc.SignalPending),
 			},
+			nil,
+			"",
 		},
 
 		// Covers the scenario of a v1.Node that contains autopilot state that indicates that
@@ -534,6 +779,8 @@ func TestSchedulableWait(t *testing.T) {
 			[]apv1beta2.PlanCommandTargetStatus{
 				apv1beta2.NewPlanCommandTargetStatus("worker0", appc.SignalCompleted),
 			},
+			nil,
+			"",
 		},
 	}
 
@@ -565,6 +812,29 @@ func TestSchedulableWait(t *testing.T) {
 
 			assert.True(t, cmp.Equal(test.expectedPlanStatusControllers, test.status.K0sUpdate.Controllers, cmpopts.IgnoreFields(apv1beta2.PlanCommandTargetStatus{}, "LastUpdatedTimestamp")))
 			assert.True(t, cmp.Equal(test.expectedPlanStatusWorkers, test.status.K0sUpdate.Workers, cmpopts.IgnoreFields(apv1beta2.PlanCommandTargetStatus{}, "LastUpdatedTimestamp")))
+			if test.expectedCommandDescription != "" {
+				assert.Contains(t, test.status.Description, test.expectedCommandDescription)
+			}
+			for name, desc := range test.expectedControllerDescriptions {
+				found := false
+				for _, cs := range test.status.K0sUpdate.Controllers {
+					if cs.Name == name {
+						assert.Equal(t, desc, cs.Description)
+						found = true
+					}
+				}
+				if !found {
+					for _, cs := range test.status.K0sUpdate.Workers {
+						if cs.Name == name {
+							assert.Equal(t, desc, cs.Description)
+							found = true
+						}
+					}
+				}
+				if !found {
+					t.Errorf("expected node %q not found in status", name)
+				}
+			}
 		})
 	}
 }

--- a/pkg/autopilot/controller/signal/common/download.go
+++ b/pkg/autopilot/controller/signal/common/download.go
@@ -83,6 +83,11 @@ func (r *downloadController) Reconcile(ctx context.Context, req cr.Request) (cr.
 		// When the download is complete move the status to `FailedDownload`
 		signalData.Status = apsigv2.NewStatus(FailedDownload)
 
+		// Persist error details so the plan controller can surface them.
+		if werr := r.delegate.WriteSignalError(ctx, r.client, signalNodeCopy, signalData.PlanID, FailedDownload, err.Error()); werr != nil {
+			logger.Warnf("Unable to write signal error to node status: %v", werr)
+		}
+
 	} else {
 		logger.Infof("Download of '%s' successful", manifest.URL)
 		// When the download is complete move the status to the success state

--- a/static/_crds/autopilot/autopilot.k0sproject.io_plans.yaml
+++ b/static/_crds/autopilot/autopilot.k0sproject.io_plans.yaml
@@ -309,6 +309,11 @@ spec:
                             description: PlanCommandTargetStatus is the status of
                               a resolved node (controller/worker).
                             properties:
+                              description:
+                                description: |-
+                                  Description is an optional human-readable explanation of the current state,
+                                  populated when the node is in a failed state.
+                                type: string
                               lastUpdatedTimestamp:
                                 description: LastUpdatedTimestamp is a timestamp of
                                   the last time the status has changed.
@@ -346,6 +351,11 @@ spec:
                             description: PlanCommandTargetStatus is the status of
                               a resolved node (controller/worker).
                             properties:
+                              description:
+                                description: |-
+                                  Description is an optional human-readable explanation of the current state,
+                                  populated when the node is in a failed state.
+                                type: string
                               lastUpdatedTimestamp:
                                 description: LastUpdatedTimestamp is a timestamp of
                                   the last time the status has changed.
@@ -371,6 +381,11 @@ spec:
                             description: PlanCommandTargetStatus is the status of
                               a resolved node (controller/worker).
                             properties:
+                              description:
+                                description: |-
+                                  Description is an optional human-readable explanation of the current state,
+                                  populated when the node is in a failed state.
+                                type: string
                               lastUpdatedTimestamp:
                                 description: LastUpdatedTimestamp is a timestamp of
                                   the last time the status has changed.


### PR DESCRIPTION
## Description

Fixes #4007

When an autopilot update fails (e.g. a binary download fails a SHA-256 checksum or can't be fetched), the only visible signal was the plan reaching `PlanApplyFailed`. There was no machine-readable explanation of _why_ it failed, where in the node fleet the failure occurred, or which plan caused it. Operators had to grep k0s logs on each node to diagnose the failure.

### New field: `PlanCommandTargetStatus.Description`

A new `description` field is added to `PlanCommandTargetStatus` (the per-node entry under `Plan.status.commands[].k0supdate.{controllers,workers}[]` and `airgapupdate.workers[]`). It is populated with the failure reason when a node reaches `SignalApplyFailed`, and is empty on success.

The existing `PlanCommandStatus.description` field is now populated via a `buildFailureSummary` helper that rolls up all failed node descriptions into a single string formatted as `"<node>: <reason>: <message>; <node>: …"`.

```yaml
# kubectl get plan autopilot -o yaml
status:
  state: PlanApplyFailed
  commands:
    - state: PlanApplyFailed
      description: "controller0: FailedDownload: sha256 mismatch (want 0000…0000, got a3f2…c1b9)"
      k0supdate:
        controllers:
          - name: controller0
            state: SignalApplyFailed
            description: "FailedDownload: sha256 mismatch (want 0000…0000, got a3f2…c1b9)"
            lastUpdatedTimestamp: "2026-03-12T12:34:56Z"
        workers: []
```

### New `k0sproject.io/autopilot-last-error` annotation

Both `ControlNode` and `Node` objects receive a `k0sproject.io/autopilot-last-error` annotation when a signal-processing failure occurs. The annotation is cleared automatically when a new signal is dispatched. Messages are truncated at 1024 bytes to avoid annotation and etcd object limits.

```yaml
# kubectl get controlnode controller0 -o yaml
metadata:
  annotations:
    k0sproject.io/autopilot-last-error: '{"planID":"plan-upgrade","reason":"FailedDownload","message":"sha256 mismatch (want 0000…0000, got a3f2…c1b9)","timestamp":"2026-03-12T12:34:56Z"}'
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Auto test added

Unit tests:
- `delegate/specialized_test.go` — `ReadSignalError`, `WriteSignalError`, `ClearSignalError` on both delegate types; message truncation; reason passthrough
- `k0supdate/schedulablewait_test.go` and `airgapupdate/schedulablewait_test.go` — `Description` propagation and `buildFailureSummary`
- `k0supdate/schedulable_test.go` and `airgapupdate/schedulable_test.go` — `ClearSignalError` called before `UpdateSignalNode`

Integration test suite `ap-signal-error` (single-controller `--single` mode, OpenRC):
- `TestControllerDownloadFailure` — plan with wrong SHA-256 targeting a controller; asserts `PlanApplyFailed`, per-node `Description`, rollup `Description`, and the `k0sproject.io/autopilot-last-error` annotation on the `ControlNode`
- `TestErrorClearedOnRetry` — submits a failing plan, waits for the error annotation, deletes the plan, submits a good plan, and asserts the annotation is cleared after success

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
