### PR TITLE
fix(autopilot): airgapupdate plan stuck on controller+worker nodes

### DIFF
--- a/inttest/Makefile.variables
+++ b/inttest/Makefile.variables
@@ -8,6 +8,7 @@ smoketests := \
 	check-addons \
 	check-airgap \
 	check-ap-airgap \
+	check-ap-airgap-controllerworker \
 	check-ap-controllerworker \
 	check-ap-ha3x3 \
 	check-ap-platformselect \
@@ -82,7 +83,8 @@ smoketests := \
 
 air_gapped_smoketests := \
 	check-airgap \
-	check-ap-airgap
+	check-ap-airgap \
+	check-ap-airgap-controllerworker
 
 ipv6_smoketests := \
 	check-calico-ipv6 \

--- a/inttest/ap-airgap-controllerworker/airgap_controllerworker_test.go
+++ b/inttest/ap-airgap-controllerworker/airgap_controllerworker_test.go
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package airgapcontrollerworker
+
+import (
+	"testing"
+
+	apconst "github.com/k0sproject/k0s/pkg/autopilot/constant"
+	appc "github.com/k0sproject/k0s/pkg/autopilot/controller/plans/core"
+	k0sclientset "github.com/k0sproject/k0s/pkg/client/clientset"
+
+	"github.com/k0sproject/k0s/inttest/common"
+	aptest "github.com/k0sproject/k0s/inttest/common/autopilot"
+
+	"github.com/stretchr/testify/suite"
+)
+
+// airgapControllerWorkerSuite verifies that autopilot airgap updates complete successfully on
+// controller+worker nodes (regression test for a bug where the plan would get stuck in
+// schedulablewait because the autopilot worker component is not started on controller+worker
+// nodes, so the airgap signal on the v1.Node object is never processed).
+type airgapControllerWorkerSuite struct {
+	common.BootlooseSuite
+}
+
+// SetupTest prepares the controller+worker node and waits for it to be ready.
+func (s *airgapControllerWorkerSuite) SetupTest() {
+	ctx := s.Context()
+
+	s.Require().NoError(s.InitController(0, "--enable-worker", "--disable-components=metrics-server"))
+	s.Require().NoError(s.WaitJoinAPI(s.ControllerNode(0)))
+
+	kc, err := s.KubeClient(s.ControllerNode(0))
+	s.Require().NoError(err)
+
+	s.Require().NoError(s.WaitForNodeReady(s.ControllerNode(0), kc))
+
+	cClient, err := s.ExtensionsClient(s.ControllerNode(0))
+	s.Require().NoError(err)
+
+	s.Require().NoError(aptest.WaitForCRDByName(ctx, cClient, "plans"))
+	s.Require().NoError(aptest.WaitForCRDByName(ctx, cClient, "controlnodes"))
+}
+
+// TestAirgapUpdateCompletesOnControllerWorkerNode verifies that an airgap update plan targeting a
+// controller+worker node reaches PlanCompleted state.
+//
+// Regression test: a change that disabled the autopilot worker component on controller+worker
+// nodes caused the airgap update to get stuck in schedulablewait because the worker component was
+// the only consumer of the airgap signal on the Node object, and it was never started on
+// controller+worker nodes.
+func (s *airgapControllerWorkerSuite) TestAirgapUpdateCompletesOnControllerWorkerNode() {
+	ctx := s.Context()
+
+	planTemplate := `
+apiVersion: autopilot.k0sproject.io/v1beta2
+kind: Plan
+metadata:
+  name: autopilot
+spec:
+  id: id123
+  timestamp: now
+  commands:
+    - airgapupdate:
+        version: v0.0.0
+        platforms:
+          linux-amd64:
+            url: http://localhost/dist/bundle.tar
+          linux-arm64:
+            url: http://localhost/dist/bundle.tar
+        workers:
+          discovery:
+            static:
+              nodes:
+                - controller0
+`
+
+	restConfig, err := s.GetKubeConfig(s.ControllerNode(0))
+	s.Require().NoError(err)
+
+	_, err = common.Create(ctx, restConfig, []byte(planTemplate))
+	s.Require().NoError(err)
+	s.T().Log("Plan created")
+
+	// The plan must reach PlanCompleted. If the controller+worker node is incorrectly left in the
+	// workers list without anything to process its airgap signal, the plan will get stuck in
+	// schedulablewait and the test will time out.
+	client, err := k0sclientset.NewForConfig(restConfig)
+	s.Require().NoError(err)
+	_, err = aptest.WaitForPlanState(ctx, client, apconst.AutopilotName, appc.PlanCompleted)
+	s.Require().NoError(err, "Airgap update plan did not complete: likely stuck in schedulablewait because the controller+worker node's airgap signal was not processed")
+
+	// Verify the airgap bundle was placed on the controller+worker node.
+	lsout, err := s.RunCommandController(0, "ls /var/lib/k0s/images/bundle.tar")
+	s.NoError(err)
+	s.NotEmpty(lsout)
+}
+
+// TestAirgapControllerWorkerSuite runs the airgap update suite against a single controller+worker
+// node to expose the schedulablewait regression.
+func TestAirgapControllerWorkerSuite(t *testing.T) {
+	suite.Run(t, &airgapControllerWorkerSuite{
+		common.BootlooseSuite{
+			ControllerCount: 1,
+			WorkerCount:     0,
+			LaunchMode:      common.LaunchModeOpenRC,
+
+			AirgapImageBundleMountPoints: []string{"/dist/bundle.tar"},
+		},
+	})
+}

--- a/pkg/autopilot/controller/signal/init.go
+++ b/pkg/autopilot/controller/signal/init.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 
+	apv1beta2 "github.com/k0sproject/k0s/pkg/apis/autopilot/v1beta2"
 	apdel "github.com/k0sproject/k0s/pkg/autopilot/controller/delegate"
 	"github.com/k0sproject/k0s/pkg/autopilot/controller/signal/airgap"
 	"github.com/k0sproject/k0s/pkg/autopilot/controller/signal/k0s"
@@ -27,6 +28,18 @@ func RegisterControllers(ctx context.Context, logger *logrus.Entry, mgr crman.Ma
 
 	if err := airgap.RegisterControllers(ctx, logger, mgr, delegate, k0sDataDir); err != nil {
 		return fmt.Errorf("unable to register airgap controllers: %w", err)
+	}
+
+	// On controller+worker nodes the autopilot worker component is not started (only the
+	// controller component runs). Airgap update signals are written to v1.Node annotations by the
+	// plan provider, so the controller must also watch v1.Node objects for airgap signals when
+	// acting as an embedded worker.
+	if enableWorker {
+		if _, isControlNode := delegate.CreateObject().(*apv1beta2.ControlNode); isControlNode {
+			if err := airgap.RegisterControllers(ctx, logger, mgr, apdel.NodeControllerDelegate(), k0sDataDir); err != nil {
+				return fmt.Errorf("unable to register airgap controllers for embedded worker node: %w", err)
+			}
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Description

Fix airgap update plans getting stuck in `SchedulableWait` on controller+worker (hybrid) nodes.

When a node runs as both a controller and worker (`--enable-worker`), only the autopilot **controller** component is started — the autopilot **worker** component is not. Airgap update signals are written as annotations on `v1.Node` objects, and the worker component is the only consumer of those signals. Since the worker component is never started on controller+worker nodes, the airgap signal on the `v1.Node` object is never processed and the plan gets permanently stuck in `SchedulableWait`.

The fix registers the airgap Node signal controllers on the controller component itself when `--enable-worker` is set and the delegate is a `ControlNode`. This ensures the airgap signal on `v1.Node` is handled even without a running worker component.

Fixes #7303

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Auto test added

A new integration test (`check-ap-airgap-controllerworker`) was added that:
1. Starts a single controller+worker node with `--enable-worker`
2. Submits an airgap update `Plan` targeting the node
3. Asserts the plan reaches `PlanCompleted` state (previously it would time out stuck in `SchedulableWait`)
4. Verifies the airgap bundle was placed on the node at `/var/lib/k0s/images/bundle.tar`

The test is added to both the `smoketests` and `air_gapped_smoketests` suites in `inttest/Makefile.variables`.

## Checklist

- [x] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [x] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
